### PR TITLE
fix(android): permission still denied after grant on Android 14

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,5 +1,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
     <uses-permission android:name="android.permission.READ_MEDIA_VIDEO" />
+    <uses-permission android:name="android.permission.READ_MEDIA_VISUAL_USER_SELECTED" />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
 </manifest>

--- a/android/src/main/java/app/capgo/plugin/photo_library/PhotoLibraryPlugin.java
+++ b/android/src/main/java/app/capgo/plugin/photo_library/PhotoLibraryPlugin.java
@@ -5,12 +5,15 @@ import android.app.Activity;
 import android.content.ClipData;
 import android.content.ContentResolver;
 import android.content.Intent;
+import android.content.pm.PackageManager;
 import android.net.Uri;
 import android.os.Build;
 import androidx.activity.result.ActivityResult;
 import androidx.annotation.NonNull;
+import androidx.core.content.ContextCompat;
 import com.getcapacitor.JSArray;
 import com.getcapacitor.JSObject;
+import com.getcapacitor.PermissionState;
 import com.getcapacitor.Plugin;
 import com.getcapacitor.PluginCall;
 import com.getcapacitor.PluginMethod;
@@ -31,6 +34,10 @@ import java.util.concurrent.Executors;
             strings = { Manifest.permission.READ_MEDIA_IMAGES, Manifest.permission.READ_MEDIA_VIDEO },
             alias = PhotoLibraryPlugin.PERMISSION_MEDIA
         ),
+        @Permission(
+            strings = { Manifest.permission.READ_MEDIA_VISUAL_USER_SELECTED },
+            alias = PhotoLibraryPlugin.PERMISSION_MEDIA_PARTIAL
+        ),
         @Permission(strings = { Manifest.permission.READ_EXTERNAL_STORAGE }, alias = PhotoLibraryPlugin.PERMISSION_MEDIA_LEGACY)
     }
 )
@@ -39,9 +46,11 @@ public class PhotoLibraryPlugin extends Plugin {
     private final String pluginVersion = "8.0.17";
 
     static final String PERMISSION_MEDIA = "media";
+    static final String PERMISSION_MEDIA_PARTIAL = "media_partial";
     static final String PERMISSION_MEDIA_LEGACY = "media_legacy";
 
     private static final String STATE_AUTHORIZED = "authorized";
+    private static final String STATE_LIMITED = "limited";
     private static final String STATE_DENIED = "denied";
 
     private final ExecutorService executor = Executors.newFixedThreadPool(2);
@@ -70,20 +79,32 @@ public class PhotoLibraryPlugin extends Plugin {
 
     @PluginMethod
     public void requestAuthorization(PluginCall call) {
-        String alias = permissionAlias();
-        if (hasPermission(alias)) {
-            call.resolve(statusObject(STATE_AUTHORIZED));
+        String state = currentAuthorizationState();
+        if (!STATE_DENIED.equals(state)) {
+            call.resolve(statusObject(state));
             return;
         }
 
         bridge.saveCall(call);
-        requestPermissionForAlias(alias, call, "permissionCallback");
+        requestPermissionForAlias(permissionAlias(), call, "permissionCallback");
     }
 
     @PermissionCallback
     private void permissionCallback(PluginCall call) {
-        String state = hasMediaPermissions() ? STATE_AUTHORIZED : STATE_DENIED;
-        call.resolve(statusObject(state));
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE && STATE_DENIED.equals(currentAuthorizationState())) {
+            PermissionState partialState = getPermissionState(PERMISSION_MEDIA_PARTIAL);
+            if (partialState != PermissionState.GRANTED && !isAndroidPermissionGranted(Manifest.permission.READ_MEDIA_VISUAL_USER_SELECTED)) {
+                requestPermissionForAlias(PERMISSION_MEDIA_PARTIAL, call, "partialPermissionCallback");
+                return;
+            }
+        }
+
+        call.resolve(statusObject(currentAuthorizationState()));
+    }
+
+    @PermissionCallback
+    private void partialPermissionCallback(PluginCall call) {
+        call.resolve(statusObject(currentAuthorizationState()));
     }
 
     @PluginMethod
@@ -316,11 +337,33 @@ public class PhotoLibraryPlugin extends Plugin {
     }
 
     private boolean hasMediaPermissions() {
-        return hasPermission(permissionAlias());
+        String state = currentAuthorizationState();
+        return STATE_AUTHORIZED.equals(state) || STATE_LIMITED.equals(state);
     }
 
     private String currentAuthorizationState() {
-        return hasMediaPermissions() ? STATE_AUTHORIZED : STATE_DENIED;
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            if (getPermissionState(PERMISSION_MEDIA) == PermissionState.GRANTED) {
+                return STATE_AUTHORIZED;
+            }
+
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+                if (
+                    getPermissionState(PERMISSION_MEDIA_PARTIAL) == PermissionState.GRANTED ||
+                    isAndroidPermissionGranted(Manifest.permission.READ_MEDIA_VISUAL_USER_SELECTED)
+                ) {
+                    return STATE_LIMITED;
+                }
+            }
+
+            return STATE_DENIED;
+        }
+
+        return getPermissionState(PERMISSION_MEDIA_LEGACY) == PermissionState.GRANTED ? STATE_AUTHORIZED : STATE_DENIED;
+    }
+
+    private boolean isAndroidPermissionGranted(String permission) {
+        return ContextCompat.checkSelfPermission(getContext(), permission) == PackageManager.PERMISSION_GRANTED;
     }
 
     private String permissionAlias() {

--- a/android/src/main/java/app/capgo/plugin/photo_library/PhotoLibraryPlugin.java
+++ b/android/src/main/java/app/capgo/plugin/photo_library/PhotoLibraryPlugin.java
@@ -34,10 +34,7 @@ import java.util.concurrent.Executors;
             strings = { Manifest.permission.READ_MEDIA_IMAGES, Manifest.permission.READ_MEDIA_VIDEO },
             alias = PhotoLibraryPlugin.PERMISSION_MEDIA
         ),
-        @Permission(
-            strings = { Manifest.permission.READ_MEDIA_VISUAL_USER_SELECTED },
-            alias = PhotoLibraryPlugin.PERMISSION_MEDIA_PARTIAL
-        ),
+        @Permission(strings = { Manifest.permission.READ_MEDIA_VISUAL_USER_SELECTED }, alias = PhotoLibraryPlugin.PERMISSION_MEDIA_PARTIAL),
         @Permission(strings = { Manifest.permission.READ_EXTERNAL_STORAGE }, alias = PhotoLibraryPlugin.PERMISSION_MEDIA_LEGACY)
     }
 )
@@ -93,7 +90,9 @@ public class PhotoLibraryPlugin extends Plugin {
     private void permissionCallback(PluginCall call) {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE && STATE_DENIED.equals(currentAuthorizationState())) {
             PermissionState partialState = getPermissionState(PERMISSION_MEDIA_PARTIAL);
-            if (partialState != PermissionState.GRANTED && !isAndroidPermissionGranted(Manifest.permission.READ_MEDIA_VISUAL_USER_SELECTED)) {
+            if (
+                partialState != PermissionState.GRANTED && !isAndroidPermissionGranted(Manifest.permission.READ_MEDIA_VISUAL_USER_SELECTED)
+            ) {
                 requestPermissionForAlias(PERMISSION_MEDIA_PARTIAL, call, "partialPermissionCallback");
                 return;
             }


### PR DESCRIPTION
## Summary
- Replace deprecated `hasPermission("media")` with `getPermissionState()` so granted Android media permissions are detected correctly
- Add `READ_MEDIA_VISUAL_USER_SELECTED` support for Android 14 partial photo access and return `limited` when only partial access is granted
- Declare the new permission in `AndroidManifest.xml`

Fixes #2

## Root cause
`hasPermission(alias)` checks the literal Android permission string passed in. Passing the Capacitor alias `"media"` always returned denied, even after the user granted access in the system dialog.

## Test plan
- [x] `bun run verify:android`
- [x] `bun run verify:web`
- [ ] `bun run verify:ios` (blocked locally: iOS SDK not installed in this environment)
- [ ] Manual test on Android 14 device: call `requestAuthorization()`, grant photos access, verify state is `authorized` or `limited` (not `denied`)


Made with [Cursor](https://cursor.com)