### PR TITLE
chore: align renovate.json with capacitor-plugin-template

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -21,15 +21,6 @@
       "automerge": true
     },
     {
-      "matchPackageNames": [
-        "eslint"
-      ],
-      "matchManagers": [
-        "npm"
-      ],
-      "enabled": false
-    },
-    {
       "matchPackagePatterns": [
         "^com\\.google\\..*"
       ],


### PR DESCRIPTION
## Summary
- Replace `renovate.json` with the canonical config from [Cap-go/capacitor-plugin-template](https://github.com/Cap-go/capacitor-plugin-template/blob/main/renovate.json)
- Removes the plugin-specific `eslint` packageRule that diverged from the template

Fixes #1

## Test plan
- [ ] CI passes
- [ ] Renovate no longer reports invalid `packageRules` settings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Re-enabled automatic updates for a previously excluded dependency, so future maintenance updates can be picked up again.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->